### PR TITLE
Fix Xray Shunt Failed

### DIFF
--- a/xray-core/Makefile
+++ b/xray-core/Makefile
@@ -45,7 +45,7 @@ endef
 
 define Package/xray-core
   $(call Package/xray/template)
-  DEPENDS:=$(GO_ARCH_DEPENDS) +ca-bundle
+  DEPENDS:=$(GO_ARCH_DEPENDS) +ca-bundle +v2ray-geoip +v2ray-geosite
 endef
 
 define Package/xray-example


### PR DESCRIPTION
Xray Shunt failed to start without geosite.dat

> Failed to start: main: failed to load config files: [/tmp/etc/passwall/TCP_DNS.json] > infra/conf: invalid field rule > infra/conf: failed to parse domain rule: geosite:category-ads > infra/conf: failed to load geosite: CATEGORY-ADS > infra/conf: failed to load file: geosite.dat > infra/conf: failed to open file: geosite.dat > open /usr/share/xray/geosite.dat: no such file or directory