### PR TITLE
Update luci-app-poweroffdevice Makefile

### DIFF
--- a/luci-app-poweroffdevice/Makefile
+++ b/luci-app-poweroffdevice/Makefile
@@ -12,7 +12,7 @@ LUCI_DESCRIPTION:=provides Web UI to shut down (power off) your device.
 
 LUCI_PKGARCH:=all
 PKG_VERSION:=1
-PKG_RELEASE:=3 
+PKG_RELEASE:=3
 
 include $(TOPDIR)/feeds/luci/luci.mk
 


### PR DESCRIPTION
Packaged contents of /workdir/openwrt/build_dir/target-aarch64_generic_musl/luci-app-poweroffdevice/ipkg-all/luci-app-poweroffdevice into /workdir/openwrt/bin/packages/aarch64_generic/small8/luci-app-poweroffdevice_1-3 _all.ipk
1.根据上方提示：luci-app-poweroffdevice_1-3 _all.ipk 此处多了空格
Makefile中
PKG_RELEASE:=3 后多了一个空格